### PR TITLE
Add missing space to root shell

### DIFF
--- a/sudo
+++ b/sudo
@@ -58,7 +58,7 @@ if [ ! -d $ROOT_HOME ]; then
 	$SU -c "$MOUNT_RW"
 	$SU -c "mkdir $ROOT_HOME"
 	$SU -c "chmod 700 $ROOT_HOME"
-	BASHRC="'PS1=\"#\"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
+	BASHRC="'PS1=\"# \"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
 	$SU -c "echo -e $BASHRC > $ROOT_HOME/.bashrc"
 	$SU -c "chmod 700 $ROOT_HOME/.bashrc"
 	$SU -c "$MOUNT_RO"


### PR DESCRIPTION
The root shell prompt was missing a space after the #.